### PR TITLE
Fix error with nested paragraphs when using DetailSummary component

### DIFF
--- a/components/DetailSummary.vue
+++ b/components/DetailSummary.vue
@@ -1,7 +1,7 @@
 <template>
   <section data-cy="DetailSummary">
-    <div class="handdraw-line" />
-    <div class="gradient" />
+    <div class="handdraw-line"></div>
+    <div class="gradient"></div>
     <div class="summary-detail__summary-card handdraw-line">
       <div class="summary-detail__author-card">
         <img
@@ -17,12 +17,12 @@
           <p>{{ formatDate(article.createdAt) }}</p>
         </div>
       </div>
-      <p
+      <div
         class="summary-detail__description"
         data-cy="DetailSummaryDescription"
       >
         <slot></slot>
-      </p>
+      </div>
       <div
         v-if="article.tags"
         :key="article.title"
@@ -78,6 +78,7 @@ export default {
 
 .summary-detail__description {
   font-size: 20px;
+  line-height: 1.75;
 }
 
 .summary-detail__basic-info {


### PR DESCRIPTION
When opening a blog page a JS error is shown, in Dev mode it says:

![image](https://user-images.githubusercontent.com/8480203/175907977-3d9f3d6e-70aa-4ca1-af54-a9139dee9c99.png)

* Error seems to come from DetailSummary.vue component
* The main slot is surrounded by a `<p>` element
* Content inserted to the slot also contains `<p>` which results in nested `<p>` which is invalid HTML and Vue/Nuxt shows error
* After the change, the error is not shown anymore
* For local production build it seems to resolve the wrapper container CSS bug 