### PR TITLE
Add missing security & a11y talks (Speaker Deck / Sessionize sync)

### DIFF
--- a/content/talks/access-granted.md
+++ b/content/talks/access-granted.md
@@ -1,0 +1,29 @@
+---
+title: Access Granted!
+description: A workshop on testing authentication with Cypress — from username/password to social and passwordless login.
+createdAt: 2024-06-06T09:00:00.000Z
+author:
+  name: Ramona Schwering
+  image: https://avatars.githubusercontent.com/u/29896429?s=120&v=4
+tags:
+- CityJS Athens 2024
+otherLanguages:
+- locale: de
+  name: german
+  path: /de/access-granted
+---
+
+## Abstract
+
+Discover the key to effortlessly testing authentication aspects with our workshop: "Access Granted." With the help of the Cypress testing framework, you'll learn how to ensure sturdy security and seamless user experiences by tackling one of the most crucial parts: The Login. So join us in exploring login page testing strategies, including the standard username-password process, social authentication, and passwordless authentication. Whether you're an experienced QA professional, a curious frontend developer, or someone passionate about testing, "Access Granted" will equip you with the skills and knowledge needed to elevate your login page testing game.
+
+## Slides
+
+::media-grid
+---
+media:
+  - name: "Slides"
+    description: "You can find the slides of the talk on speakerdeck"
+    url: "https://speakerdeck.com/leichteckig/access-granted"
+---
+::

--- a/content/talks/cake-is-a-lie.md
+++ b/content/talks/cake-is-a-lie.md
@@ -1,0 +1,53 @@
+---
+title: The Cake Is a Lie... And So Is Your Login's Accessibility
+description: Debugging the accessibility of a real React login live with a screen reader — ARIA, focus management and accessible auth.
+createdAt: 2025-07-09T09:00:00.000Z
+author:
+  name: Ramona Schwering
+  image: https://avatars.githubusercontent.com/u/29896429?s=120&v=4
+tags:
+- WeAreDevelopers World Congress 2025
+- KCDC 2025
+- React Summit US 2025
+- React Advanced 2025
+- React Paris 2026
+- JNation 2026
+- enterJS 2026
+otherLanguages:
+- locale: de
+  name: german
+  path: /de/cake-is-a-lie
+---
+
+## Abstract
+
+Much like the promise of cake in Portal, login forms are everywhere in web development. While they may seem functional at first glance, many users with disabilities encounter a maze of invisible walls, from keyboard traps to inaccessible CAPTCHAs. It's as if GLaDOS designed these forms herself to test us!
+
+In this session, we will debug the accessibility issues of a real React login component live, similar to traversing those test chambers: Using an actual screen reader, we'll show how small improvements, such as proper ARIA implementation and effective focus management, can transform a complex test chamber into a smooth user experience. Additionally, we will address the common pitfalls that GLaDOS might throw at us in both the Portal universe and the real world. Last but not least, we'll discover authentication features, which will help us keep authentication accessible for everyone.
+
+## Slides
+
+::media-grid
+---
+media:
+  - name: "Slides"
+    description: "You can find the slides of the talk on speakerdeck"
+    url: "https://speakerdeck.com/leichteckig/the-cake-is-a-lie-dot-dot-dot-and-so-is-your-logins-accessibility"
+---
+::
+
+## Recording
+
+::media-grid
+---
+media:
+  - name: "JNation 2026"
+    url: "https://www.youtube-nocookie.com/embed/uqXJpaqxw6M"
+  - name: "Nordic.js 2025"
+    url: "https://www.youtube-nocookie.com/embed/zChAUo9TMNY"
+  - name: "Future Frontend 2026"
+    url: "https://www.youtube-nocookie.com/embed/dRM3xTvxdhg"
+  - name: "BeJS"
+    url: "https://www.youtube-nocookie.com/embed/9SC0y5ngLsE"
+---
+::

--- a/content/talks/dangerous-reactivity.md
+++ b/content/talks/dangerous-reactivity.md
@@ -1,0 +1,44 @@
+---
+title: "Dangerous Reactivity: Why AI Output Is the New XSS"
+description: Treating LLM output as trusted is the new v-html mistake — OWASP LLM05 and how to safely render AI-generated content.
+createdAt: 2026-06-03T09:00:00.000Z
+author:
+  name: Ramona Schwering
+  image: https://avatars.githubusercontent.com/u/29896429?s=120&v=4
+tags:
+- NDC Copenhagen 2026
+- WeAreDevelopers World Congress 2026
+- React Advanced London 2026
+- SymfonyCon Warsaw 2026
+otherLanguages:
+- locale: de
+  name: german
+  path: /de/dangerous-reactivity
+---
+
+## Abstract
+
+Vue developers know one golden rule: never use v-html on user input. This or something similar is well-known in other frameworks, too. Yet, as we're integrating Large Language Models (LLMs) into our applications, we often make a fatal mistake. We're treating AI output as a trusted source. This is fine, right? Well, not automatically.
+
+Let's look at OWASP LLM05 and how "Improper Output Handling" impacts the security of our components. Therefore, let's discuss examples where safe inputs can trick models, causing vulnerabilities like XSS and injection attacks. By the end, you'll learn how to be "professionally pessimistic" for AI. You'll learn how to sanitize LLM data, safely render Markdown, and manage AI-generated content. Join my session to approach technology with caution, I look forward to exploring this with you!
+
+## Slides
+
+::media-grid
+---
+media:
+  - name: "Slides"
+    description: "You can find the slides of the talk on speakerdeck"
+    url: "https://speakerdeck.com/leichteckig/dangerous-reactivity-why-ai-output-is-the-new-xss-vue"
+---
+::
+
+## Recording
+
+::media-grid
+---
+media:
+  - name: "NDC Copenhagen 2026"
+    url: "https://www.youtube-nocookie.com/embed/1uhV9yR-WZg"
+---
+::

--- a/content/talks/de/access-granted.md
+++ b/content/talks/de/access-granted.md
@@ -1,0 +1,29 @@
+---
+title: Access Granted!
+description: A workshop on testing authentication with Cypress — from username/password to social and passwordless login.
+createdAt: 2024-06-06T09:00:00.000Z
+author:
+  name: Ramona Schwering
+  image: https://avatars.githubusercontent.com/u/29896429?s=120&v=4
+tags:
+- CityJS Athens 2024
+otherLanguages:
+- locale: en
+  name: english
+  path: /access-granted
+---
+
+## Kurzfassung
+
+Entdecke in unserem Workshop „Access Granted“ den Schlüssel, um Authentifizierungsaspekte mühelos zu testen. Mithilfe des Test-Frameworks Cypress lernst Du, robuste Sicherheit und ein reibungsloses Nutzererlebnis für einen der wichtigsten Bereiche sicherzustellen: das Login. Gemeinsam erkunden wir Strategien zum Testen von Login-Seiten – vom klassischen Nutzername-Passwort-Verfahren über Social Authentication bis hin zu passwortlosem Login. Ob Du erfahrene QA-Fachkraft, neugierige:r Frontend-Entwickler:in oder einfach begeistert vom Testen bist: „Access Granted“ vermittelt Dir die Fähigkeiten und das Wissen, um Dein Login-Testing auf das nächste Level zu heben.
+
+## Folien
+
+::media-grid
+---
+media:
+  - name: "Folien"
+    description: "Die Folien des Vortrags findest Du auf Speakerdeck"
+    url: "https://speakerdeck.com/leichteckig/access-granted"
+---
+::

--- a/content/talks/de/cake-is-a-lie.md
+++ b/content/talks/de/cake-is-a-lie.md
@@ -1,0 +1,53 @@
+---
+title: The Cake Is a Lie... And So Is Your Login's Accessibility
+description: Debugging the accessibility of a real React login live with a screen reader — ARIA, focus management and accessible auth.
+createdAt: 2025-07-09T09:00:00.000Z
+author:
+  name: Ramona Schwering
+  image: https://avatars.githubusercontent.com/u/29896429?s=120&v=4
+tags:
+- WeAreDevelopers World Congress 2025
+- KCDC 2025
+- React Summit US 2025
+- React Advanced 2025
+- React Paris 2026
+- JNation 2026
+- enterJS 2026
+otherLanguages:
+- locale: en
+  name: english
+  path: /cake-is-a-lie
+---
+
+## Kurzfassung
+
+Ähnlich wie das Versprechen des Kuchens in Portal sind Login-Formulare im Web allgegenwärtig. Auf den ersten Blick wirken sie funktional, doch viele Menschen mit Behinderungen stoßen auf ein Labyrinth unsichtbarer Wände – von Keyboard-Traps bis hin zu unzugänglichen CAPTCHAs. Fast so, als hätte GLaDOS diese Formulare selbst entworfen, um uns zu testen!
+
+In dieser Session debuggen wir die Barrierefreiheit einer echten React-Login-Komponente live, ganz so, als würden wir die Testkammern durchqueren: Mit einem echten Screenreader zeigen wir, wie kleine Verbesserungen – etwa eine korrekte ARIA-Umsetzung und effektives Fokus-Management – eine komplizierte Testkammer in ein reibungsloses Nutzererlebnis verwandeln. Außerdem gehen wir auf die typischen Stolperfallen ein, die GLaDOS uns sowohl im Portal-Universum als auch in der echten Welt stellen könnte. Zu guter Letzt entdecken wir Authentifizierungs-Features, die uns helfen, Authentifizierung für alle zugänglich zu halten.
+
+## Folien
+
+::media-grid
+---
+media:
+  - name: "Folien"
+    description: "Die Folien des Vortrags findest Du auf Speakerdeck"
+    url: "https://speakerdeck.com/leichteckig/the-cake-is-a-lie-dot-dot-dot-and-so-is-your-logins-accessibility"
+---
+::
+
+## Aufzeichnungen
+
+::media-grid
+---
+media:
+  - name: "JNation 2026"
+    url: "https://www.youtube-nocookie.com/embed/uqXJpaqxw6M"
+  - name: "Nordic.js 2025"
+    url: "https://www.youtube-nocookie.com/embed/zChAUo9TMNY"
+  - name: "Future Frontend 2026"
+    url: "https://www.youtube-nocookie.com/embed/dRM3xTvxdhg"
+  - name: "BeJS"
+    url: "https://www.youtube-nocookie.com/embed/9SC0y5ngLsE"
+---
+::

--- a/content/talks/de/dangerous-reactivity.md
+++ b/content/talks/de/dangerous-reactivity.md
@@ -1,0 +1,44 @@
+---
+title: "Dangerous Reactivity: Why AI Output Is the New XSS"
+description: Treating LLM output as trusted is the new v-html mistake — OWASP LLM05 and how to safely render AI-generated content.
+createdAt: 2026-06-03T09:00:00.000Z
+author:
+  name: Ramona Schwering
+  image: https://avatars.githubusercontent.com/u/29896429?s=120&v=4
+tags:
+- NDC Copenhagen 2026
+- WeAreDevelopers World Congress 2026
+- React Advanced London 2026
+- SymfonyCon Warsaw 2026
+otherLanguages:
+- locale: en
+  name: english
+  path: /dangerous-reactivity
+---
+
+## Kurzfassung
+
+Vue-Entwickler:innen kennen eine goldene Regel: Niemals `v-html` auf Nutzereingaben anwenden. Diese oder eine ähnliche Regel ist auch in anderen Frameworks bekannt. Doch wenn wir Large Language Models (LLMs) in unsere Anwendungen integrieren, machen wir oft einen fatalen Fehler: Wir behandeln die Ausgabe der KI als vertrauenswürdige Quelle. Das ist doch in Ordnung, oder? Nun ja, nicht automatisch.
+
+Werfen wir einen Blick auf OWASP LLM05 und darauf, wie „Improper Output Handling“ die Sicherheit unserer Komponenten beeinflusst. Anhand von Beispielen sehen wir, wie sichere Eingaben Modelle austricksen und Schwachstellen wie XSS und Injection-Angriffe verursachen können. Am Ende weißt Du, wie Du gegenüber KI „professionell pessimistisch“ bleibst: Du lernst, LLM-Daten zu bereinigen, Markdown sicher zu rendern und KI-generierte Inhalte im Griff zu behalten. Komm in meine Session und lass uns Technologie mit der nötigen Vorsicht angehen – ich freue mich darauf!
+
+## Folien
+
+::media-grid
+---
+media:
+  - name: "Folien"
+    description: "Die Folien des Vortrags findest Du auf Speakerdeck"
+    url: "https://speakerdeck.com/leichteckig/dangerous-reactivity-why-ai-output-is-the-new-xss-vue"
+---
+::
+
+## Aufzeichnungen
+
+::media-grid
+---
+media:
+  - name: "NDC Copenhagen 2026"
+    url: "https://www.youtube-nocookie.com/embed/1uhV9yR-WZg"
+---
+::

--- a/content/talks/de/from-the-crypt-to-the-code.md
+++ b/content/talks/de/from-the-crypt-to-the-code.md
@@ -1,0 +1,42 @@
+---
+title: From the Crypt to the Code
+description: A chilling journey through the most common web vulnerabilities — explored through the lens of horror movies.
+createdAt: 2024-11-18T09:00:00.000Z
+author:
+  name: Ramona Schwering
+  image: https://avatars.githubusercontent.com/u/29896429?s=120&v=4
+tags:
+- JSNation US 2024
+- Vue.js Nation 2025
+otherLanguages:
+- locale: en
+  name: english
+  path: /from-the-crypt-to-the-code
+---
+
+## Kurzfassung
+
+Eine unheilvolle Videokassette, die ihre Zuschauer heimsucht, eine gestaltwandelnde Kreatur in einer Forschungsstation oder ein Astronaut, der ahnungslos ein Alien an Bord eines Raumschiffs bringt – kommen Dir diese Szenarien bekannt vor? Diese Horrorfilm-Plots haben Ähnlichkeiten mit Szenarien der Web-Sicherheit, die Dir bereits begegnet sind. Begleite mich auf einer schaurigen Reise durch die Web-Sicherheit, auf der wir die häufigsten Schwachstellen durch die Brille von Horrorfilmen betrachten. Von den heimtückischen Injection-Lücken à la „Alien“ bis zum schaurigen Schrecken gebrochener Authentifizierung wie in „Unfriended“. Aber keine Sorge: Wir beleuchten auch Lösungen in der Web-Entwicklung und verwandeln diese Sicherheitsalpträume in Geschichten des Triumphs. Wenn Du Dich traust, komm mit und lerne, wie Du die von Deinen Web-Anwendungen heraufbeschworene Dunkelheit besiegst.
+
+## Folien
+
+::media-grid
+---
+media:
+  - name: "Folien"
+    description: "Die Folien des Vortrags findest Du auf Speakerdeck"
+    url: "https://speakerdeck.com/leichteckig/from-the-crypt-to-the-code"
+---
+::
+
+## Aufzeichnungen
+
+::media-grid
+---
+media:
+  - name: "JNation"
+    url: "https://www.youtube-nocookie.com/embed/t_sVcThe6xs"
+  - name: "DevWorld"
+    url: "https://www.youtube-nocookie.com/embed/ugFHvbA1ewI"
+---
+::

--- a/content/talks/de/plants-vs-thieves.md
+++ b/content/talks/de/plants-vs-thieves.md
@@ -1,0 +1,47 @@
+---
+title: "Plants vs Thieves: Automated Tests in the World of Web Security"
+description: Using the Plants vs. Zombies analogy to show how automated tests defend your web app against security threats.
+createdAt: 2024-06-04T09:00:00.000Z
+author:
+  name: Ramona Schwering
+  image: https://avatars.githubusercontent.com/u/29896429?s=120&v=4
+tags:
+- Frontend Nation 2024
+- SymfonyLive Berlin 2024
+- WeAreDevelopers World Congress 2024
+- React Day Berlin 2024
+- NDC Security 2025
+otherLanguages:
+- locale: en
+  name: english
+  path: /plants-vs-thieves
+---
+
+## Kurzfassung
+
+Web-Sicherheit ist entscheidend in einem sich ständig wandelnden Umfeld, in dem potenzielle Bedrohungen allgegenwärtig sind. Um das Konzept besser zu verstehen, können wir uns unsere Web-Anwendung als Garten oder als Zuhause vorstellen, das vor möglichen Angriffen geschützt werden muss. Wir ziehen dabei Parallelen zum beliebten Spiel „Plants vs. Zombies“, in dem es darum geht, den eigenen Garten vor Eindringlingen zu schützen.
+
+Unsere automatisierten Tests fungieren als fleißige Wächter, deren oberstes Ziel es ist, potenzielle Schwachstellen zu erkennen und zu beheben – ganz ähnlich dem vielfältigen Pflanzen-Arsenal im Spiel. Statt den Sicherheitsprozess als endlosen Kampf zu begreifen, schauen wir uns an, wie automatisierte Tests als Verteidiger gegen mögliche Probleme wirken, seien es Zombies oder Diebe. Neben einem Überblick über nützliche Werkzeuge betonen wir die Bedeutung grundlegender Testarten wie Unit- oder End-to-End-Tests für die Absicherung Deines digitalen Gartens.
+
+Komm in diese Session, um zu verstehen, wie Du durch Testautomatisierung eine sichere Umgebung für Deine Web-Anwendung schaffst. Dieser Ansatz sorgt dafür, dass Deine Web-Anwendungen den Herausforderungen durch Cyber-Bedrohungen erfolgreich begegnen, ohne dass Du gänzlich neue, dedizierte Tools einführen musst.
+
+## Folien
+
+::media-grid
+---
+media:
+  - name: "Folien"
+    description: "Die Folien des Vortrags findest Du auf Speakerdeck"
+    url: "https://speakerdeck.com/leichteckig/plants-vs-thieves-automated-tests-in-the-world-of-web-security"
+---
+::
+
+## Aufzeichnungen
+
+::media-grid
+---
+media:
+  - name: "NDC Security 2025"
+    url: "https://www.youtube-nocookie.com/embed/zq1pnFMwHE4"
+---
+::

--- a/content/talks/de/react-with-caution.md
+++ b/content/talks/de/react-with-caution.md
@@ -1,0 +1,40 @@
+---
+title: "React with Caution: How to Hack Your React App (And Fix It Too)"
+description: A hands-on session hacking a React app to expose real-world threats like XSS and injection — and how to fix them.
+createdAt: 2026-06-05T09:00:00.000Z
+author:
+  name: Ramona Schwering
+  image: https://avatars.githubusercontent.com/u/29896429?s=120&v=4
+tags:
+- React Miami 2026
+- React Norway 2026
+otherLanguages:
+- locale: en
+  name: english
+  path: /react-with-caution
+---
+
+## Kurzfassung
+
+React hat Dir den Rücken frei – zumindest auf dem Papier. Mit fast keinen CVEs in den letzten Jahren gehört React Core zu den sichersten Frontend-Frameworks überhaupt. Doch Sicherheit gibt es nicht automatisch. In dieser praxisnahen Hands-on-Session hackt Ramona live eine React-Anwendung, um reale Bedrohungen wie XSS, Injection-Angriffe und subtile Frontend-Schwachstellen aufzudecken. Du lernst, wo React Dich standardmäßig schützt, wo eben nicht und wie Du zur letzten Verteidigungslinie für Deine Nutzer:innen wirst.
+
+## Folien
+
+::media-grid
+---
+media:
+  - name: "Folien"
+    description: "Die Folien des Vortrags findest Du auf Speakerdeck"
+    url: "https://speakerdeck.com/leichteckig/react-with-caution-how-to-hack-your-react-app-and-fix-it-too"
+---
+::
+
+## Aufzeichnungen
+
+::media-grid
+---
+media:
+  - name: "React Miami 2026"
+    url: "https://www.youtube-nocookie.com/embed/qFd9sT9Bogw"
+---
+::

--- a/content/talks/de/vuetiful-defense.md
+++ b/content/talks/de/vuetiful-defense.md
@@ -1,0 +1,41 @@
+---
+title: Vue'tiful Defense
+description: Let's sketch secure Vue development live on stage — bringing threats and their defenses to life as sketch notes.
+createdAt: 2026-03-11T09:00:00.000Z
+author:
+  name: Ramona Schwering
+  image: https://avatars.githubusercontent.com/u/29896429?s=120&v=4
+tags:
+- VueJS Amsterdam 2026
+otherLanguages:
+- locale: en
+  name: english
+  path: /vuetiful-defense
+---
+
+## Kurzfassung
+
+Für viele Entwickler:innen klingt das Thema Sicherheit in Vue einschüchternd oder langweilig. Diese Session dreht diesen Eindruck komplett um: Ich zeichne meine Sketchnotes zu sicherer Vue-Entwicklung live auf der Bühne – gemeinsam mit Dir ❤️ Wir reden nicht nur über Bedrohungen, wir erwecken sie als Sketchnotes auf der großen Leinwand von VueJS Amsterdam zum Leben! Anschließend entdecken und entwerfen wir als Team die „magische“ Rüstung, die unsere App braucht. Dabei lernen wir auch unsere Verbündeten kennen, etwa das OWASP-Projekt.
+
+Mein Ziel ist, dass alle den Raum selbstbewusst verlassen und bereit sind, in ihrem Team zum Security Champion zu werden – ausgestattet mit einem Sketchnote-Handout. So verbindet meine Session zwei meiner größten Leidenschaften: hochwertige Software zu bauen und komplexe Themen durch Kunst zugänglich und fesselnd zu machen.
+
+## Folien
+
+::media-grid
+---
+media:
+  - name: "Folien"
+    description: "Die Folien des Vortrags findest Du auf Speakerdeck"
+    url: "https://speakerdeck.com/leichteckig/vuetiful-defense"
+---
+::
+
+## Aufzeichnungen
+
+::media-grid
+---
+media:
+  - name: "VueJS Amsterdam 2026"
+    url: "https://www.youtube-nocookie.com/embed/y752-F2vWvk"
+---
+::

--- a/content/talks/de/you-shall-not-pass.md
+++ b/content/talks/de/you-shall-not-pass.md
@@ -1,0 +1,29 @@
+---
+title: You shall not pass!? A short story of customizable login experiences
+description: Train your app's bouncer — a delightful journey into customized authentication from the developer's point of view.
+createdAt: 2024-06-08T09:00:00.000Z
+author:
+  name: Ramona Schwering
+  image: https://avatars.githubusercontent.com/u/29896429?s=120&v=4
+tags:
+- CityJS Athens 2024
+otherLanguages:
+- locale: en
+  name: english
+  path: /you-shall-not-pass
+---
+
+## Kurzfassung
+
+Ob wir selbst dort waren oder es nur aus den Medien kennen: Manchmal regeln Türsteher den Einlass, etwa in einen Club oder zu einer Konferenz. „You shall not pass“ ist ein Satz, den Du vielleicht schon einmal gehört hast. Auch unsere Web-Anwendung kann Türsteher haben – die Einlass zu geschützten Seiten gewähren oder eben nicht. Das ist allerdings nicht die typische Authentifizierungs-Reise, die Du vielleicht erwartest: Begleite mich auf einer kleinen, aber vergnüglichen Reise, auf der wir den Türsteher mithilfe einer angepassten Authentifizierung trainieren – aus der Sicht der Entwickler:innen, die sie bauen. Login-Erlebnisse zu individualisieren muss schließlich keine lästige Pflicht sein.
+
+## Folien
+
+::media-grid
+---
+media:
+  - name: "Folien"
+    description: "Die Folien des Vortrags findest Du auf Speakerdeck"
+    url: "https://speakerdeck.com/leichteckig/you-shall-not-pass-a-short-story-of-customizable-login-experiences"
+---
+::

--- a/content/talks/from-the-crypt-to-the-code.md
+++ b/content/talks/from-the-crypt-to-the-code.md
@@ -1,0 +1,42 @@
+---
+title: From the Crypt to the Code
+description: A chilling journey through the most common web vulnerabilities — explored through the lens of horror movies.
+createdAt: 2024-11-18T09:00:00.000Z
+author:
+  name: Ramona Schwering
+  image: https://avatars.githubusercontent.com/u/29896429?s=120&v=4
+tags:
+- JSNation US 2024
+- Vue.js Nation 2025
+otherLanguages:
+- locale: de
+  name: german
+  path: /de/from-the-crypt-to-the-code
+---
+
+## Abstract
+
+A cryptic videotape haunting its viewers, a shape-shifting entity haunting a research station, or an astronaut unknowingly carrying an alien onto a spaceship—do these scenarios sound familiar? These horror movie plots share similarities with scenarios in web security you have already encountered. Join me on a chilling journey through web security as we explore the most common vulnerabilities through the lens of horror movies. From the sinister injection flaws reminiscent of "Alien" to the terrifying specter of broken authentication akin to "Unfriended". But don't worry, we'll also shed light on solutions in web development, turning these security nightmares into tales of triumph. If you dare, join us and learn how to conquer the darkness invited by your web applications.
+
+## Slides
+
+::media-grid
+---
+media:
+  - name: "Slides"
+    description: "You can find the slides of the talk on speakerdeck"
+    url: "https://speakerdeck.com/leichteckig/from-the-crypt-to-the-code"
+---
+::
+
+## Recording
+
+::media-grid
+---
+media:
+  - name: "JNation"
+    url: "https://www.youtube-nocookie.com/embed/t_sVcThe6xs"
+  - name: "DevWorld"
+    url: "https://www.youtube-nocookie.com/embed/ugFHvbA1ewI"
+---
+::

--- a/content/talks/plants-vs-thieves.md
+++ b/content/talks/plants-vs-thieves.md
@@ -1,0 +1,47 @@
+---
+title: "Plants vs Thieves: Automated Tests in the World of Web Security"
+description: Using the Plants vs. Zombies analogy to show how automated tests defend your web app against security threats.
+createdAt: 2024-06-04T09:00:00.000Z
+author:
+  name: Ramona Schwering
+  image: https://avatars.githubusercontent.com/u/29896429?s=120&v=4
+tags:
+- Frontend Nation 2024
+- SymfonyLive Berlin 2024
+- WeAreDevelopers World Congress 2024
+- React Day Berlin 2024
+- NDC Security 2025
+otherLanguages:
+- locale: de
+  name: german
+  path: /de/plants-vs-thieves
+---
+
+## Abstract
+
+Web security is crucial in a constantly evolving environment where potential threats are always present. To better understand this concept, we can imagine our web application as a garden or a home that needs to be protected from possible attacks. We can draw parallels with the popular game "Plants vs. Zombies," which aims to safeguard your garden from intruders.
+
+Our automated tests function as diligent guardians whose primary objective is to identify and address potential vulnerabilities, much like the diverse plant arsenal in the game. Instead of framing the security process as a never-ending fight, we will explore how automated tests act as defenders against possible issues, whether they are zombies or intruders. Next to an overview of tools you can utilize, we emphasize the importance of fundamental testing types, such as unit or end-to-end tests, in securing your digital garden.
+
+Join this session to understand how to create a secure environment for your web application through test automation. This approach ensures that your web applications can successfully navigate the challenges posed by cyber threats without the necessity of introducing entirely new dedicated tools.
+
+## Slides
+
+::media-grid
+---
+media:
+  - name: "Slides"
+    description: "You can find the slides of the talk on speakerdeck"
+    url: "https://speakerdeck.com/leichteckig/plants-vs-thieves-automated-tests-in-the-world-of-web-security"
+---
+::
+
+## Recording
+
+::media-grid
+---
+media:
+  - name: "NDC Security 2025"
+    url: "https://www.youtube-nocookie.com/embed/zq1pnFMwHE4"
+---
+::

--- a/content/talks/react-with-caution.md
+++ b/content/talks/react-with-caution.md
@@ -1,0 +1,40 @@
+---
+title: "React with Caution: How to Hack Your React App (And Fix It Too)"
+description: A hands-on session hacking a React app to expose real-world threats like XSS and injection — and how to fix them.
+createdAt: 2026-06-05T09:00:00.000Z
+author:
+  name: Ramona Schwering
+  image: https://avatars.githubusercontent.com/u/29896429?s=120&v=4
+tags:
+- React Miami 2026
+- React Norway 2026
+otherLanguages:
+- locale: de
+  name: german
+  path: /de/react-with-caution
+---
+
+## Abstract
+
+React has your back, at least on paper. With almost no CVEs in recent years, React Core stands out as one of the most secure frontend frameworks available. But security isn't automatic. In this practical, hands-on session, Ramona will actively hack a React application to expose real-world threats like XSS, injection attacks, and subtle frontend vulnerabilities. You'll learn where React protects you by default, where it doesn't, and how to become the final line of defense for your users.
+
+## Slides
+
+::media-grid
+---
+media:
+  - name: "Slides"
+    description: "You can find the slides of the talk on speakerdeck"
+    url: "https://speakerdeck.com/leichteckig/react-with-caution-how-to-hack-your-react-app-and-fix-it-too"
+---
+::
+
+## Recording
+
+::media-grid
+---
+media:
+  - name: "React Miami 2026"
+    url: "https://www.youtube-nocookie.com/embed/qFd9sT9Bogw"
+---
+::

--- a/content/talks/vuetiful-defense.md
+++ b/content/talks/vuetiful-defense.md
@@ -1,0 +1,41 @@
+---
+title: Vue'tiful Defense
+description: Let's sketch secure Vue development live on stage — bringing threats and their defenses to life as sketch notes.
+createdAt: 2026-03-11T09:00:00.000Z
+author:
+  name: Ramona Schwering
+  image: https://avatars.githubusercontent.com/u/29896429?s=120&v=4
+tags:
+- VueJS Amsterdam 2026
+otherLanguages:
+- locale: de
+  name: german
+  path: /de/vuetiful-defense
+---
+
+## Abstract
+
+For many developers, learning about security in Vue can sound intimidating or boring. This session is designed to flip that impression on its head completely - I will draw my sketch notes on secure Vue development live on stage, together with you ❤️ We won't just talk about threats; we will bring them to life as sketch notes on the big screen of VueJS Amsterdam! Then, as a team, we'll discover and design the "magical" armor our app needs. Along with learning about our allies, such as the OWASP project.
+
+My goal is for everyone to leave the room feeling confident and ready to be a security champion on their team, armed with a sketch note handout. This way, my session combines two of my greatest passions: building high-quality software and making complex topics accessible and engaging through art.
+
+## Slides
+
+::media-grid
+---
+media:
+  - name: "Slides"
+    description: "You can find the slides of the talk on speakerdeck"
+    url: "https://speakerdeck.com/leichteckig/vuetiful-defense"
+---
+::
+
+## Recording
+
+::media-grid
+---
+media:
+  - name: "VueJS Amsterdam 2026"
+    url: "https://www.youtube-nocookie.com/embed/y752-F2vWvk"
+---
+::

--- a/content/talks/you-shall-not-pass.md
+++ b/content/talks/you-shall-not-pass.md
@@ -1,0 +1,29 @@
+---
+title: You shall not pass!? A short story of customizable login experiences
+description: Train your app's bouncer — a delightful journey into customized authentication from the developer's point of view.
+createdAt: 2024-06-08T09:00:00.000Z
+author:
+  name: Ramona Schwering
+  image: https://avatars.githubusercontent.com/u/29896429?s=120&v=4
+tags:
+- CityJS Athens 2024
+otherLanguages:
+- locale: de
+  name: german
+  path: /de/you-shall-not-pass
+---
+
+## Abstract
+
+Whether we're there or only know it from the media, sometimes bouncers guide entry, e.g. to a club or a conference. "You shall not pass" is a quote you might have heard of. Our web application might also have bouncers - granting entry to projected pages or not. However, this is not the typical authentication journey you might expect: Join me on a small but delightful journey to train the bouncer by using a customized authentication - from the eyes of the developer building it. Customizing login experiences doesn't need to be a drag, after all.
+
+## Slides
+
+::media-grid
+---
+media:
+  - name: "Slides"
+    description: "You can find the slides of the talk on speakerdeck"
+    url: "https://speakerdeck.com/leichteckig/you-shall-not-pass-a-short-story-of-customizable-login-experiences"
+---
+::


### PR DESCRIPTION
Sync the talks collection with speakerdeck.com/leichteckig and Sessionize, adding 9 talks (EN + DE) that were missing:

- Access Granted!
- Plants vs Thieves: Automated Tests in the World of Web Security
- You shall not pass!? A short story of customizable login experiences
- From the Crypt to the Code
- The Cake Is a Lie... And So Is Your Login's Accessibility
- Vue'tiful Defense
- Dangerous Reactivity: Why AI Output Is the New XSS
- React with Caution: How to Hack Your React App (And Fix It Too)

Event tags derived from content/conferences, recordings sourced from the "Conferences" YouTube playlist where available.