### PR TITLE
Fix full-width layout on direct page loads

### DIFF
--- a/app/assets/main.css
+++ b/app/assets/main.css
@@ -122,6 +122,26 @@ h6 {
   font-size: 20px;
 }
 
+/* Global layout utilities — used across pages/components (Header, Footer, Page, …).
+   Must live here, not in a page's <style>, so they are present on direct loads of any route. */
+.container {
+  max-width: 1280px;
+  padding: 0 40px;
+  margin: 0 auto;
+}
+
+.gradient {
+  height: 30px;
+
+  background: repeating-linear-gradient(
+    45deg,
+    var(--border-color),
+    var(--border-color) 1px,
+    var(--bg) 1px,
+    var(--bg) 10px
+  );
+}
+
 .handdraw-line {
   border-bottom: solid 3px var(--border-color);
   border-bottom-right-radius: 255px 15px;

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -119,12 +119,6 @@ useHead({
   margin-bottom: 30px;
 }
 
-.container {
-  max-width: 1280px;
-  padding: 0 40px;
-  margin: 0 auto;
-}
-
 .moe__title {
   margin-bottom: 20px;
 }
@@ -144,18 +138,6 @@ useHead({
   justify-content: center;
   text-align: center;
   margin-bottom: 50px;
-}
-
-.gradient {
-  height: 30px;
-
-  background: repeating-linear-gradient(
-    45deg,
-    var(--border-color),
-    var(--border-color) 1px,
-    var(--bg) 1px,
-    var(--bg) 10px
-  );
 }
 
 @media screen and (min-width: 800px) {


### PR DESCRIPTION
The global .container and .gradient rules lived in an unscoped <style> block of pages/index.vue. Nuxt code-splits page CSS, so on a direct load of any other route (e.g. /blog/) those rules were missing and the layout stretched to full viewport width.

Move both utilities into assets/main.css, which is loaded globally.