### PR TITLE
feat: add RSS feed for blog articles

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -20,7 +20,7 @@ export default defineNuxtConfig({
   nitro: {
     prerender: {
       crawlLinks: true,
-      routes: ['/'],
+      routes: ['/', '/rss.xml'],
       failOnError: false
     }
   },
@@ -57,7 +57,13 @@ export default defineNuxtConfig({
       ],
       link: [
         { rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' },
-        { rel: 'me', href: 'https://hachyderm.io/@leichteckig' }
+        { rel: 'me', href: 'https://hachyderm.io/@leichteckig' },
+        {
+          rel: 'alternate',
+          type: 'application/rss+xml',
+          title: 'Ramona Schwering — Writing',
+          href: '/rss.xml'
+        }
       ]
     }
   },

--- a/server/routes/rss.xml.get.ts
+++ b/server/routes/rss.xml.get.ts
@@ -1,0 +1,60 @@
+import { queryCollection } from '@nuxt/content/server'
+
+const SITE_URL = 'https://www.ramona.codes'
+
+// Republished/syndicated articles point their canonical at the original
+// publication and are kept out of search indexing (see robots config in
+// nuxt.config.ts). Keep them out of the feed too, matched by the same slug
+// prefixes so the feed stays consistent with what we ask crawlers to index.
+const SYNDICATED_PREFIXES = ['smashing-', 'auth0-', 'devto-']
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+export default defineEventHandler(async (event) => {
+  const articles = await queryCollection(event, 'articles_en')
+    .select('title', 'description', 'stem', 'createdAt')
+    .order('createdAt', 'DESC')
+    .all()
+
+  const items = articles
+    .map(article => ({ ...article, slug: article.stem.split('/').pop() as string }))
+    .filter(article => !SYNDICATED_PREFIXES.some(prefix => article.slug.startsWith(prefix)))
+
+  const feedItems = items.map((article) => {
+    const url = `${SITE_URL}/blog/${article.slug}/`
+    return `    <item>
+      <title>${escapeXml(article.title ?? '')}</title>
+      <link>${url}</link>
+      <guid isPermaLink="true">${url}</guid>
+      <pubDate>${new Date(article.createdAt).toUTCString()}</pubDate>
+      <description>${escapeXml(article.description ?? '')}</description>
+    </item>`
+  }).join('\n')
+
+  const lastBuildDate = items.length
+    ? new Date(items[0].createdAt).toUTCString()
+    : new Date(0).toUTCString()
+
+  const feed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Ramona Schwering — Writing</title>
+    <link>${SITE_URL}/blog/</link>
+    <description>Articles by Ramona Schwering on frontend development, test automation and accessibility.</description>
+    <language>en</language>
+    <lastBuildDate>${lastBuildDate}</lastBuildDate>
+    <atom:link href="${SITE_URL}/rss.xml" rel="self" type="application/rss+xml" />
+${feedItems}
+  </channel>
+</rss>`
+
+  setResponseHeader(event, 'Content-Type', 'application/rss+xml; charset=utf-8')
+  return feed
+})


### PR DESCRIPTION
Add a /rss.xml Nitro route that queries the articles_en collection (newest first) and emits a valid RSS 2.0 feed. Syndicated/republished articles (smashing-, auth0-, devto- slug prefixes) are excluded to match the robots indexing policy. XML special characters are escaped.

- server/routes/rss.xml.get.ts: the feed handler
- nuxt.config.ts: RSS autodiscovery <link rel="alternate"> in <head>
  and /rss.xml added to the prerender routes for static generation

Verified via dev server: HTTP 200 with application/rss+xml, well-formed XML (xmllint), 4 items (11 EN articles minus 7 syndicated), no syndicated entries, all item URLs resolve 200, no server errors.